### PR TITLE
Fix NSS libdir detection for ARM32 systems - Update nss.yaml

### DIFF
--- a/catalog/commons/nss.yaml
+++ b/catalog/commons/nss.yaml
@@ -7,7 +7,7 @@ hooks:
     actions:
       - |-
         NSS_CHK_SIGN_LIBS="${NSS_CHK_SIGN_LIBS:-freebl3 nssdbm3 softokn3}"
-        LIBS=${LIBS:-/usr/lib64}
+        LIBS=${LIBS:-/usr/$(get_libdir)}
         shlibsign=${shlibsign:-shlibsign}
 
         if [ -n "${DEBUG}" ] ; then 


### PR DESCRIPTION
This PR fixes NSS hook libdir detection on ARM 32-bit systems.

The previous implementation hardcoded:
```
/usr/lib64
```

which causes postinst failures on ARM32, where NSS libraries are installed under:
```
/usr/lib
```

The fix replaces the hardcoded path with:
```
/usr/$(get_libdir)
```

allowing the hooks to work correctly across different system architectures and libdir layouts.

This issue was originally reported in https://github.com/macaroni-os/mark-issues/issues/695